### PR TITLE
Issue 3746 - Misleding error message "OP has no effect in expression XXX)

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3655,8 +3655,13 @@ Statement *ReturnStatement::semantic(Scope *sc)
          *      exp; return;
          */
         Statement *s = new ExpStatement(loc, exp);
-        exp = NULL;
         s = s->semantic(sc);
+
+        if (exp->type->ty != Tvoid && !exp->checkSideEffect(2))
+            error("expression with no side effects used with void return");
+
+        exp = NULL;
+
         return new CompoundStatement(loc, s, this);
     }
 


### PR DESCRIPTION
Issue 3746 - Misleding error message "OP has no effect in expression XXX), in void function

Better error message when returning an expression with no side effects from a void function.

After semantic, re-run checkSideEffect while gagged and use global.errors to determine if the expression had side effects.
