### PR TITLE
Issue 6228 - ICE(e2ir.c:1323, 2.053) on {auto x = (*ptr) ^^ y} with const

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10771,7 +10771,7 @@ Expression *PowExp::semantic(Scope *sc)
         if ((e2->op == TOKint64 && e2->toInteger() == 0) ||
                 (e2->op == TOKfloat64 && e2->toReal() == 0.0))
         {
-            if (e1->op == TOKint64)
+            if (e1->type->isintegral())
                 e = new IntegerExp(loc, 1, e1->type);
             else
                 e = new RealExp(loc, 1.0, e1->type);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3204,6 +3204,17 @@ pure int test4031()
 } 
  
 /***************************************************/
+// 6228
+
+
+void test6228()
+{
+    const(int)* ptr;
+    const(int)  temp;
+    auto x = (*ptr) ^^ temp;
+}
+
+/***************************************************/
 
 struct S6230 {
     int p;
@@ -3464,6 +3475,7 @@ int main()
     test6230();
     test6264();
     test5046();
+    test6228();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Issue 6228 - ICE(e2ir.c:1323, 2.053) on {auto x = (*ptr) ^^ y} with const integer types

Use the correct check to determine if e1 is an integer, this avoids creating a RealExp of type int when e1 is not an integer literal.
