### PR TITLE
Issue 1692 - Abstract class dynamic creation bug

### DIFF
--- a/src/toobj.c
+++ b/src/toobj.c
@@ -554,6 +554,8 @@ void ClassDeclaration::toObjFile(int multiobj)
     flags |= 32;
     if (ctor)
         flags |= 8;
+    if (isabstract)
+        flags |= 64;
     for (ClassDeclaration *cd = this; cd; cd = cd->baseClass)
     {
         if (cd->members)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3257,6 +3257,16 @@ pure int test4031()
     static const int x = 8; 
     return x; 
 } 
+
+/***************************************************/
+// 1962
+
+
+void test1962()
+{
+    class C { abstract void x(); }
+    assert(C.classinfo.create() is null);
+}
  
 /***************************************************/
 // 6228
@@ -3637,6 +3647,7 @@ int main()
     test136();
     test137();
     test138();
+    test1962();
     test139();
     test140();
     test141();


### PR DESCRIPTION
Add a flag to TypeInfoClass etc to mark classes that cannot be constructed
