### PR TITLE
Issue 1891 - Array-concatenation of T* and T*[] produces corrupted result

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2112,77 +2112,44 @@ elem *CatExp::toElem(IRState *irs)
 
     Type *tb1 = e1->type->toBasetype();
     Type *tb2 = e2->type->toBasetype();
-    Type *tn;
 
-#if 0
-    if ((tb1->ty == Tarray || tb1->ty == Tsarray) &&
-        (tb2->ty == Tarray || tb2->ty == Tsarray)
-       )
-#endif
+    Type *ta = (tb1->ty == Tarray || tb1->ty == Tsarray) ? tb1 : tb2;
+    Type *tn = ta->nextOf();
 
-    Type *ta = tb1->nextOf() ? e1->type : e2->type;
-    tn = tb1->nextOf() ? tb1->nextOf() : tb2->nextOf();
+    if (e1->op == TOKcat)
     {
-        if (e1->op == TOKcat)
-        {
-            elem *ep;
-            CatExp *ce = this;
-            int n = 2;
+        elem *ep;
+        CatExp *ce = this;
+        int n = 2;
 
-            ep = eval_Darray(irs, ce->e2);
-            do
-            {
-                n++;
-                ce = (CatExp *)ce->e1;
-                ep = el_param(ep, eval_Darray(irs, ce->e2));
-            } while (ce->e1->op == TOKcat);
-            ep = el_param(ep, eval_Darray(irs, ce->e1));
-#if 1
-            ep = el_params(
-                           ep,
-                           el_long(TYsize_t, n),
-                           ta->getTypeInfo(NULL)->toElem(irs),
-                           NULL);
-            e = el_bin(OPcall, TYdarray, el_var(rtlsym[RTLSYM_ARRAYCATNT]), ep);
-            e->Eflags |= EFLAGS_variadic;
-#else
-            ep = el_params(
-                           ep,
-                           el_long(TYsize_t, n),
-                           el_long(TYsize_t, tn->size()),
-                           NULL);
-            e = el_bin(OPcall, TYdarray, el_var(rtlsym[RTLSYM_ARRAYCATN]), ep);
-            e->Eflags |= EFLAGS_variadic;
-#endif
-        }
-        else
+        ep = eval_Darray(irs, ce->e2);
+        do
         {
-            elem *e1;
-            elem *e2;
-            elem *ep;
-
-            e1 = eval_Darray(irs, this->e1);
-            e2 = eval_Darray(irs, this->e2);
-#if 1
-            ep = el_params(e2, e1, ta->getTypeInfo(NULL)->toElem(irs), NULL);
-            e = el_bin(OPcall, TYdarray, el_var(rtlsym[RTLSYM_ARRAYCATT]), ep);
-#else
-            ep = el_params(el_long(TYsize_t, tn->size()), e2, e1, NULL);
-            e = el_bin(OPcall, TYdarray, el_var(rtlsym[RTLSYM_ARRAYCAT]), ep);
-#endif
-        }
-        el_setLoc(e,loc);
-    }
-#if 0
-    else if ((tb1->ty == Tarray || tb1->ty == Tsarray) &&
-             e2->type->equals(tb1->next))
-    {
-        error("array cat with element not implemented");
-        e = el_long(TYint, 0);
+            n++;
+            ce = (CatExp *)ce->e1;
+            ep = el_param(ep, eval_Darray(irs, ce->e2));
+        } while (ce->e1->op == TOKcat);
+        ep = el_param(ep, eval_Darray(irs, ce->e1));
+        ep = el_params(
+                       ep,
+                       el_long(TYsize_t, n),
+                       ta->getTypeInfo(NULL)->toElem(irs),
+                       NULL);
+        e = el_bin(OPcall, TYdarray, el_var(rtlsym[RTLSYM_ARRAYCATNT]), ep);
+        e->Eflags |= EFLAGS_variadic;
     }
     else
-        assert(0);
-#endif
+    {
+        elem *e1;
+        elem *e2;
+        elem *ep;
+
+        e1 = eval_Darray(irs, this->e1);
+        e2 = eval_Darray(irs, this->e2);
+        ep = el_params(e2, e1, ta->getTypeInfo(NULL)->toElem(irs), NULL);
+        e = el_bin(OPcall, TYdarray, el_var(rtlsym[RTLSYM_ARRAYCATT]), ep);
+    }
+    el_setLoc(e,loc);
     return e;
 }
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2106,6 +2106,27 @@ void test116()
 }
 
 /***************************************************/
+
+void test1891()
+{
+    struct C {
+        char[8] x = "helloabc";
+    }
+
+    int main()
+    {
+        C* a = new C;
+        C*[] b;
+        b ~= new C;
+
+        auto g = a ~ b;
+        assert(g[0] && g[1] && g[0].x == g[1].x);
+
+        return 0;
+    }
+}
+
+/***************************************************/
 // Bugzilla 4291
 
 void test117() pure
@@ -3395,6 +3416,7 @@ int main()
 
     test127();
     test128();
+    test1891();
     test129();
     test130();
     test131();


### PR DESCRIPTION
Issue 1891 - Array-concatenation of T\* and T*[] produces corrupted result

CatExp::toElem was a mess, using Type::nextOf to determine if a type was an array.  Naturally this failed when the first type derived from TypeNext but was not an array.

This also cleans out a bunch of dead code from CatExp::toElem, that seems to have been there since 2.011.
