### PR TITLE
Issue 4460 - Regression(2.036) ICE(e2ir.c) when compiling foreach over as

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1849,7 +1849,7 @@ Lagain:
                 }
             }
 
-            if (tab->ty == Taarray)
+            if (taa)
             {
                 // Check types
                 Parameter *arg = (Parameter *)arguments->data[0];


### PR DESCRIPTION
Issue 4460 - Regression(2.036) ICE(e2ir.c) when compiling foreach over associative array literal

Fix bug where proper checks are not done on AA's in foreach, ending up with the wrong type.
