### PR TITLE
Issue 6289 - Make slices of const/immutable arrays mutable (but keep the 

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8744,12 +8744,11 @@ Lagain:
         return e;
     }
 
-    if (t->ty == Tarray)
-    {
+    type = t->nextOf()->arrayOf();
+    // Allow typedef[] -> typedef[]
+    if (type->equals(t))
         type = e1->type;
-    }
-    else
-        type = t->nextOf()->arrayOf();
+
     return e;
 
 Lerror:

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3557,6 +3557,18 @@ void test157()
 
 /***************************************************/
 
+
+void test6289()
+{
+    typedef immutable(int)[] X;
+    static assert(is(typeof(X.init[]) == X));
+    static assert(is(typeof((immutable(int[])).init[]) == immutable(int)[]));
+    static assert(is(typeof((const(int[])).init[]) == const(int)[]));
+    static assert(is(typeof((const(int[3])).init[]) == const(int)[]));
+}
+
+/***************************************************/
+
 int main()
 {
     test1();
@@ -3694,6 +3706,7 @@ int main()
     test131();
     test132();
     test133();
+    test6289();
     test134();
     test135();
     test136();


### PR DESCRIPTION
Issue 6289 - Make slices of const/immutable arrays mutable (but keep the elements const/immutable)

The if condition can be removed once typedef has been removed from the language.
