### PR TITLE
Issue 6259 - Regression(2.054 beta): Property getters returning ref const

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9419,7 +9419,7 @@ Expression *AssignExp::semantic(Scope *sc)
          *      f(value)
          */
         TypeFunction *tf = (TypeFunction *)t1;
-        if (tf->isref)
+        if (tf->isref && tf->next && tf->next->isMutable())
         {
             // Rewrite e1 = e2 to e1() = e2
             e1 = resolveProperties(sc, e1);

--- a/test/runnable/property.d
+++ b/test/runnable/property.d
@@ -7,7 +7,7 @@ struct Foo
     int bar() { return 73; }
 }
 
-int main()
+void test1()
 {
     Foo f;
     int i;
@@ -18,7 +18,22 @@ int main()
 
     i = f.bar;
     assert(i == 73);
-
-    return 0;
 }
 
+/***************************************************/
+
+@property ref const(int) bug6259() { return *(new int); }
+@property void bug6259(int) {}
+
+void test6259()
+{
+    bug6259 = 3;
+}
+
+/***************************************************/
+
+void main()
+{
+    test1();
+    test6259();
+}


### PR DESCRIPTION
Issue 6259 - Regression(2.054 beta): Property getters returning ref const() cause setters to be hidden

Do not match ref return properties when the returned value is not mutable.
