### PR TITLE
remaining issues

### DIFF
--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -220,6 +220,43 @@ void test6286()
     dst = 4;
     int[4][4] x;
     x = dst;
+
+    // fixed array have value semantic and copying from/to const is
+    // allowed as long as their element type has no aliasing
+    const(int[3]) cints = [3, 1, 2];
+    immutable(int[3]) iints = [3, 1, 2];
+    int[3] ints = cints;
+    assert(ints == cints);
+    assert(ints !is cints);
+
+    ints = iints;
+    assert(ints == iints);
+    assert(ints !is iints);
+
+    int[3] ints2;
+    ints2 = ints;
+    assert(ints2 == ints);
+    assert(ints2 !is ints);
+
+    const(int[3]) cints2 = ints2;
+    assert(cints2 == ints2);
+    assert(cints2 !is ints2);
+
+    // initializing immutable doesn't work ???
+    // immutable(int[3]) iints2 = ints2;
+
+    // with aliasing
+    int ia, ib, ic;
+    immutable(int) iia, iib, iic;
+
+    static assert(!is(typeof({immutable(int*[3]) iptrs = [&ia, &ib, &ic];})));
+    immutable(int*[3]) iptrs = [&iia, &iib, &iic];
+    int*[3] ptrs = [&ia, &ib, &ic];
+    const(int*[3]) cptrs = iptrs;
+    const(int*[3]) cptrs2 = ptrs;
+
+    static assert(!is(typeof({int*[3] ptrs = cptrs;})));
+    static assert(!is(typeof({immutable(int*[3]) iptrs = cptrs;})));
 }
 
 /***************************************************/


### PR DESCRIPTION
- Initializing a const(int[3]) with an int[3] remains broken.
- I think even the immutable(int[3]) initialization should
  work, but it may be a different topic because it never did recently.
